### PR TITLE
Corrected description of delete triggers command in fblangref25-psql.xml

### DIFF
--- a/src/docs/refdocs/langref/fblangref25/fblangref25-psql.xml
+++ b/src/docs/refdocs/langref/fblangref25/fblangref25-psql.xml
@@ -641,8 +641,8 @@ ALTER TRIGGER trigname
 
     <section id="fblangref25-psql-triggerdelete">
       <title>Deleting a Trigger</title>
-      <para>The <database>DROP TRIGGER</database> statement is used to delete stored
-      procedures.</para>
+      <para>The <database>DROP TRIGGER</database> statement is used to delete 
+      triggers.</para>
       <formalpara>
         <title>Syntax (complete)</title>
         <blockquote><programlisting>


### PR DESCRIPTION
DROP TRIGGERS statements is used to delete triggers, not to delete procedures. I think this is a typo.