### PR TITLE
Fix switched tab types in regex WHITESPACE class

### DIFF
--- a/src/docs/refdocs/langref/fblangref25/fblangref25-commons.xml
+++ b/src/docs/refdocs/langref/fblangref25/fblangref25-commons.xml
@@ -1327,7 +1327,7 @@ select 0xFFFFFFFFFFFFFFFF from rdb$database  -- returns -1
                   </formalpara>
 
                   <formalpara><title>[:WHITESPACE:]</title>
-                    <para>Matches vertical tab (ASCII 9), linefeed (ASCII 10), horizontal
+                    <para>Matches horizontal tab (ASCII 9), linefeed (ASCII 10), vertical
                     tab (ASCII 11), formfeed (ASCII 12), carriage return (ASCII 13) and space (ASCII 32).</para>
                   </formalpara>
                 </para>


### PR DESCRIPTION
Character 9 is horizontal tab and 11 is vertical tab, see https://en.wikipedia.org/wiki/ASCII 