### PR TITLE
Missing hex-string literal + SQL conformance of date/timestamp literal

### DIFF
--- a/src/docs/refdocs/langref/fblangref25/fblangref25-structure.xml
+++ b/src/docs/refdocs/langref/fblangref25/fblangref25-structure.xml
@@ -274,9 +274,9 @@
           real - 0.0, -3.14, 3.23e-23;
           string - 'text', 'don''t!';
           binary string - x'48656C6C6F20776F726C64'
-          date - DATE '10.01.2014';
-          time - TIME '15:12:56';
-          timestamp - TIMESTAMP '10.01.2014 13:32:02';
+          date - DATE'2018-01-19';
+          time - TIME'15:12:56';
+          timestamp - TIMESTAMP'2018-01-19 13:32:02';
           null state - null
      </literallayout>
      <para>Details about handling the literals for each data type are discussed in the next

--- a/src/docs/refdocs/langref/fblangref25/fblangref25-structure.xml
+++ b/src/docs/refdocs/langref/fblangref25/fblangref25-structure.xml
@@ -273,6 +273,7 @@
           integer - 0, -34, 45, 0X080000000;
           real - 0.0, -3.14, 3.23e-23;
           string - 'text', 'don''t!';
+          binary string - x'48656C6C6F20776F726C64'
           date - DATE '10.01.2014';
           time - TIME '15:12:56';
           timestamp - TIMESTAMP '10.01.2014 13:32:02';


### PR DESCRIPTION
Adds example of missing binary string literal, and changes example date format to the YYYY-MM-DD format that is specified in the SQL standard.