### PR TITLE
Add missing value of NETWORK_PROTOCOL context variable

### DIFF
--- a/src/docs/asciidoc/en/refdocs/fblangref30/_fblangref30-functions-scalar.adoc
+++ b/src/docs/asciidoc/en/refdocs/fblangref30/_fblangref30-functions-scalar.adoc
@@ -68,7 +68,7 @@ Both namespace and variable names must be given as single-quoted, case-sensitive
 [[fblangref30-funcs-tbl-systemnamespace]]
 .Context variables in the SYSTEM namespace
 `CLIENT_ADDRESS`::
-For TCPv4, this is the IP address.
+For TCPv4 and TCPv6, this is the IP address.
 For XNET, the local process ID.
 For all other protocols this variable is `NULL`.
 
@@ -88,7 +88,7 @@ The Firebird engine (server) version.
 The isolation level of the current transaction: `'READ COMMITTED'`, `'SNAPSHOT'` or `'CONSISTENCY'`.
 
 `NETWORK_PROTOCOL`::
-The protocol used for the connection: `'TCPv4'`, `'WNET'`, `'XNET'` or `NULL`.
+The protocol used for the connection: `'TCPv4'`, `'TCPv6'`, `'WNET'`, `'XNET'` or `NULL`.
 
 `SESSION_ID`::
 Same as global <<fblangref30-contextvars-current-connection>> variable.

--- a/src/docs/asciidoc/en/refdocs/fblangref40/_fblangref40-functions-scalar.adoc
+++ b/src/docs/asciidoc/en/refdocs/fblangref40/_fblangref40-functions-scalar.adoc
@@ -68,7 +68,7 @@ Both namespace and variable names must be given as single-quoted, case-sensitive
 [[fblangref40-funcs-tbl-systemnamespace]]
 .Context variables in the SYSTEM namespace
 `CLIENT_ADDRESS`::
-For TCPv4, this is the IP address.
+For TCPv4 and TCPv6, this is the IP address.
 For XNET, the local process ID.
 For all other protocols this variable is `NULL`.
 
@@ -100,7 +100,7 @@ External connection pool size
 The isolation level of the current transaction: `'READ COMMITTED'`, `'SNAPSHOT'` or `'CONSISTENCY'`.
 
 `NETWORK_PROTOCOL`::
-The protocol used for the connection: `'TCPv4'`, `'WNET'`, `'XNET'` or `NULL`.
+The protocol used for the connection: `'TCPv4'`, `'TCPv6'`, `'WNET'`, `'XNET'` or `NULL`.
 
 `SESSION_ID`::
 Same as global <<fblangref40-contextvars-current-connection>> variable.


### PR DESCRIPTION
According to FirebirdSQL's core  code 'TCPv6' is a viable value for the NETWORK_PROTOCOL context variable.
* https://github.com/FirebirdSQL/firebird/blob/82da31ccfd9a3f3daa692aa9ed70588854d15bcd/doc/sql.extensions/README.context_variables2#L50