### PR TITLE
Fixed small typo on the byte range that encloses hdr_shadow_count

### DIFF
--- a/src/docs/asciidoc/en/firebirddocs/firebirdinternals/firebird-internals.adoc
+++ b/src/docs/asciidoc/en/firebirddocs/firebirdinternals/firebird-internals.adoc
@@ -410,7 +410,7 @@ The remaining files in the database have this field set to zero.
 
 `hdr_shadow_count`::
 Four bytes, signed.
-Bytes 0x38 - 0x3c on the page.
+Bytes 0x38 - 0x3b on the page.
 Holds the event count for shadow file synchronisation for this database.
 The remaining files in the database have this field set to zero.
 


### PR DESCRIPTION
On the `hdr_shadow_count` description it was said that the field has 2 bytes, but the range contains three. Fixed the typo so it is consistent with the data type size and the following field's description.